### PR TITLE
feat: Ignored Apps — exclude list to prevent LEGACY_STORAGE conflicts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ main ]
     tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,11 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".IgnoredAppsActivity"
+            android:exported="false"
+            android:label="Ignored Apps" />
+
         <service
             android:name=".FixerService"
             android:exported="false"

--- a/app/src/main/java/com/omersusin/storagefixer/IgnoredAppsActivity.java
+++ b/app/src/main/java/com/omersusin/storagefixer/IgnoredAppsActivity.java
@@ -1,0 +1,170 @@
+package com.omersusin.storagefixer;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.CheckBox;
+import android.widget.ImageView;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.SearchView;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class IgnoredAppsActivity extends AppCompatActivity {
+
+    private AppListAdapter adapter;
+    private List<AppEntry> allApps;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_ignored_apps);
+
+        ListView listView = findViewById(R.id.appListView);
+        SearchView searchView = findViewById(R.id.searchView);
+        searchView.setQueryHint("Search apps...");
+
+        allApps = loadInstalledApps();
+        adapter = new AppListAdapter(allApps);
+        listView.setAdapter(adapter);
+
+        searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextSubmit(String query) {
+                return false;
+            }
+
+            @Override
+            public boolean onQueryTextChange(String newText) {
+                adapter.filter(newText);
+                return true;
+            }
+        });
+    }
+
+    private List<AppEntry> loadInstalledApps() {
+        PackageManager pm = getPackageManager();
+        List<ApplicationInfo> apps = pm.getInstalledApplications(
+                PackageManager.ApplicationInfoFlags.of(0));
+        Set<String> ignoredSet = IgnoredAppsManager.getIgnoredApps(this);
+
+        List<AppEntry> entries = new ArrayList<>();
+        String selfPkg = getPackageName();
+
+        for (ApplicationInfo app : apps) {
+            // Skip system apps and self
+            if ((app.flags & ApplicationInfo.FLAG_SYSTEM) != 0) continue;
+            if (app.packageName.equals(selfPkg)) continue;
+
+            String label = pm.getApplicationLabel(app).toString();
+            Drawable icon = pm.getApplicationIcon(app);
+            boolean ignored = ignoredSet.contains(app.packageName);
+
+            entries.add(new AppEntry(app.packageName, label, icon, ignored));
+        }
+
+        // Sort: ignored apps first, then alphabetically by label
+        Collections.sort(entries, (a, b) -> {
+            if (a.ignored != b.ignored) return a.ignored ? -1 : 1;
+            return a.label.compareToIgnoreCase(b.label);
+        });
+
+        return entries;
+    }
+
+    private static class AppEntry {
+        final String packageName;
+        final String label;
+        final Drawable icon;
+        boolean ignored;
+
+        AppEntry(String packageName, String label, Drawable icon, boolean ignored) {
+            this.packageName = packageName;
+            this.label = label;
+            this.icon = icon;
+            this.ignored = ignored;
+        }
+    }
+
+    private class AppListAdapter extends BaseAdapter {
+        private List<AppEntry> displayList;
+        private String currentFilter = "";
+
+        AppListAdapter(List<AppEntry> apps) {
+            this.displayList = new ArrayList<>(apps);
+        }
+
+        void filter(String query) {
+            currentFilter = query == null ? "" : query.toLowerCase().trim();
+            displayList.clear();
+            for (AppEntry app : allApps) {
+                if (currentFilter.isEmpty()
+                        || app.label.toLowerCase().contains(currentFilter)
+                        || app.packageName.toLowerCase().contains(currentFilter)) {
+                    displayList.add(app);
+                }
+            }
+            notifyDataSetChanged();
+        }
+
+        @Override
+        public int getCount() {
+            return displayList.size();
+        }
+
+        @Override
+        public AppEntry getItem(int position) {
+            return displayList.get(position);
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            if (convertView == null) {
+                convertView = LayoutInflater.from(IgnoredAppsActivity.this)
+                        .inflate(R.layout.item_ignored_app, parent, false);
+            }
+
+            AppEntry entry = getItem(position);
+
+            ImageView icon = convertView.findViewById(R.id.appIcon);
+            TextView name = convertView.findViewById(R.id.appName);
+            TextView pkg = convertView.findViewById(R.id.appPackage);
+            CheckBox checkBox = convertView.findViewById(R.id.appCheckBox);
+
+            icon.setImageDrawable(entry.icon);
+            name.setText(entry.label);
+            pkg.setText(entry.packageName);
+
+            // Prevent listener from firing during recycling
+            checkBox.setOnCheckedChangeListener(null);
+            checkBox.setChecked(entry.ignored);
+
+            checkBox.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                entry.ignored = isChecked;
+                IgnoredAppsManager.setIgnored(
+                        IgnoredAppsActivity.this, entry.packageName, isChecked);
+            });
+
+            // Make the whole row clickable to toggle
+            convertView.setOnClickListener(v -> checkBox.toggle());
+
+            return convertView;
+        }
+    }
+}

--- a/app/src/main/java/com/omersusin/storagefixer/IgnoredAppsManager.java
+++ b/app/src/main/java/com/omersusin/storagefixer/IgnoredAppsManager.java
@@ -1,0 +1,79 @@
+package com.omersusin.storagefixer;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Manages the list of apps that should be skipped during fix operations.
+ * Apps in this list will not have their FUSE directories or AppOps modified.
+ *
+ * Persisted via SharedPreferences as a Set of package names.
+ */
+public class IgnoredAppsManager {
+
+    private static final String PREFS_NAME = "ignored_apps_prefs";
+    private static final String KEY_IGNORED = "ignored_packages";
+
+    private IgnoredAppsManager() {}
+
+    /**
+     * Returns an unmodifiable set of currently ignored package names.
+     */
+    public static Set<String> getIgnoredApps(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        Set<String> stored = prefs.getStringSet(KEY_IGNORED, null);
+        if (stored == null) return Collections.emptySet();
+        // Return a copy -- getStringSet may return a reference that shouldn't be modified
+        return Collections.unmodifiableSet(new HashSet<>(stored));
+    }
+
+    /**
+     * Checks whether a specific package is in the ignored list.
+     */
+    public static boolean isIgnored(Context context, String packageName) {
+        return getIgnoredApps(context).contains(packageName);
+    }
+
+    /**
+     * Adds a package to the ignored list.
+     */
+    public static void addIgnoredApp(Context context, String packageName) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        Set<String> current = new HashSet<>(getIgnoredApps(context));
+        current.add(packageName);
+        prefs.edit().putStringSet(KEY_IGNORED, current).apply();
+    }
+
+    /**
+     * Removes a package from the ignored list.
+     */
+    public static void removeIgnoredApp(Context context, String packageName) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        Set<String> current = new HashSet<>(getIgnoredApps(context));
+        current.remove(packageName);
+        prefs.edit().putStringSet(KEY_IGNORED, current).apply();
+    }
+
+    /**
+     * Sets the ignored state for a package.
+     */
+    public static void setIgnored(Context context, String packageName, boolean ignored) {
+        if (ignored) {
+            addIgnoredApp(context, packageName);
+        } else {
+            removeIgnoredApp(context, packageName);
+        }
+    }
+
+    /**
+     * Replaces the entire ignored set at once (used for bulk updates).
+     */
+    public static void setIgnoredApps(Context context, Set<String> packages) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        prefs.edit().putStringSet(KEY_IGNORED, new HashSet<>(packages)).apply();
+    }
+}

--- a/app/src/main/java/com/omersusin/storagefixer/MainActivity.java
+++ b/app/src/main/java/com/omersusin/storagefixer/MainActivity.java
@@ -34,6 +34,7 @@ public class MainActivity extends AppCompatActivity {
         Button btnRefresh = findViewById(R.id.btnRefreshLog);
         Button btnCopy = findViewById(R.id.btnCopyLog);
         Button btnClear = findViewById(R.id.btnClearLog);
+        Button btnIgnored = findViewById(R.id.btnIgnoredApps);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS)
@@ -66,6 +67,11 @@ public class MainActivity extends AppCompatActivity {
         btnClear.setOnClickListener(v -> {
             FixerLog.clear();
             logView.setText("Log cleared.");
+        });
+
+        btnIgnored.setOnClickListener(v -> {
+            Intent ignoredIntent = new Intent(this, IgnoredAppsActivity.class);
+            startActivity(ignoredIntent);
         });
 
         checkStatus();

--- a/app/src/main/java/com/omersusin/storagefixer/PackageReceiver.java
+++ b/app/src/main/java/com/omersusin/storagefixer/PackageReceiver.java
@@ -14,6 +14,11 @@ public class PackageReceiver extends BroadcastReceiver {
         if (pkg == null) return;
         if (pkg.equals(context.getPackageName())) return;
 
+        if (IgnoredAppsManager.isIgnored(context, pkg)) {
+            FixerLog.i("Skipping ignored app: " + pkg);
+            return;
+        }
+
         FixerLog.i("Package event: " + intent.getAction() + " -> " + pkg);
 
         PendingResult pending = goAsync();

--- a/app/src/main/java/com/omersusin/storagefixer/StorageFixer.java
+++ b/app/src/main/java/com/omersusin/storagefixer/StorageFixer.java
@@ -8,6 +8,7 @@ import com.topjohnwu.superuser.Shell;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public class StorageFixer {
 
@@ -249,12 +250,19 @@ public class StorageFixer {
         int fixedDirs = 0;
         int fixedAppops = 0;
         int skipped = 0;
+        int ignored = 0;
         List<String> fixedPkgs = new ArrayList<>();
+        Set<String> ignoredApps = IgnoredAppsManager.getIgnoredApps(ctx);
 
         for (ApplicationInfo app : apps) {
             if ((app.flags & ApplicationInfo.FLAG_SYSTEM) != 0) continue;
             String pkg = app.packageName;
             if (pkg.equals(ctx.getPackageName())) continue;
+
+            if (ignoredApps.contains(pkg)) {
+                ignored++;
+                continue;
+            }
 
             boolean dirsBroken = needsFix(pkg);
             boolean appopsBroken = needsAppopsFix(pkg);
@@ -289,7 +297,8 @@ public class StorageFixer {
 
         FixerLog.i("Done: " + fixedDirs + " dirs fixed, "
                 + fixedAppops + " appops fixed, "
-                + skipped + " already OK");
+                + skipped + " already OK, "
+                + ignored + " ignored");
         return results;
     }
 
@@ -331,31 +340,40 @@ public class StorageFixer {
         FixerLog.i("Needs dir fix: " + (needsFix(pkg) ? "YES" : "NO"));
         FixerLog.i("Needs appops fix: " + (needsAppopsFix(pkg) ? "YES" : "NO"));
 
+        boolean isIgnored = IgnoredAppsManager.isIgnored(ctx, pkg);
+        if (isIgnored) {
+            FixerLog.w("WARNING: " + pkg + " is in the Ignored Apps list — skipping fix");
+        }
+
         FixerLog.i("=== CURRENT STATE ===");
         for (String type : DIR_TYPES) {
             logDirState("LOWER", LOWER + "/" + type + "/" + pkg);
             logDirState("FUSE", FUSE + "/" + type + "/" + pkg);
         }
 
-        FixerLog.i("=== APPLYING FIX ===");
-        fixPackage(ctx, pkg, true);
+        if (isIgnored) {
+            FixerLog.i("=== FIX SKIPPED (app is ignored) ===");
+        } else {
+            FixerLog.i("=== APPLYING FIX ===");
+            fixPackage(ctx, pkg, true);
 
-        forceStopPackage(pkg);
+            forceStopPackage(pkg);
 
-        try { Thread.sleep(3000); } catch (InterruptedException ignored) {}
+            try { Thread.sleep(3000); } catch (InterruptedException e) { /* ignored */ }
 
-        FixerLog.i("=== POST-FIX (3s after force-stop) ===");
-        for (String type : DIR_TYPES) {
-            logDirState("LOWER-FINAL", LOWER + "/" + type + "/" + pkg);
-            logDirState("FUSE-FINAL", FUSE + "/" + type + "/" + pkg);
-        }
+            FixerLog.i("=== POST-FIX (3s after force-stop) ===");
+            for (String type : DIR_TYPES) {
+                logDirState("LOWER-FINAL", LOWER + "/" + type + "/" + pkg);
+                logDirState("FUSE-FINAL", FUSE + "/" + type + "/" + pkg);
+            }
 
-        FixerLog.i("=== FINAL WRITE TESTS ===");
-        for (String type : DIR_TYPES) {
-            boolean lower = testWrite(LOWER + "/" + type + "/" + pkg);
-            boolean fuse = testWrite(FUSE + "/" + type + "/" + pkg);
-            FixerLog.i("  " + type + ": lower=" + (lower ? "PASS" : "FAIL")
-                    + " fuse=" + (fuse ? "PASS" : "FAIL"));
+            FixerLog.i("=== FINAL WRITE TESTS ===");
+            for (String type : DIR_TYPES) {
+                boolean lower = testWrite(LOWER + "/" + type + "/" + pkg);
+                boolean fuse = testWrite(FUSE + "/" + type + "/" + pkg);
+                FixerLog.i("  " + type + ": lower=" + (lower ? "PASS" : "FAIL")
+                        + " fuse=" + (fuse ? "PASS" : "FAIL"));
+            }
         }
 
         FixerLog.divider();

--- a/app/src/main/res/layout/activity_ignored_apps.xml
+++ b/app/src/main/res/layout/activity_ignored_apps.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Ignored Apps"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="4dp" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Checked apps will be skipped during fix operations.\nUse this for apps where LEGACY_STORAGE breaks media permissions."
+        android:textSize="12sp"
+        android:textColor="#666666"
+        android:layout_marginBottom="8dp" />
+
+    <androidx.appcompat.widget.SearchView
+        android:id="@+id/searchView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:background="#0A000000" />
+
+    <ListView
+        android:id="@+id/appListView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:divider="#1A000000"
+        android:dividerHeight="1dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -82,6 +82,14 @@
             style="?attr/materialButtonOutlinedStyle" />
     </LinearLayout>
 
+    <Button
+        android:id="@+id/btnIgnoredApps"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Ignored Apps"
+        android:layout_marginBottom="8dp"
+        style="?attr/materialButtonOutlinedStyle" />
+
     <ScrollView
         android:id="@+id/scrollView"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_ignored_app.xml
+++ b/app/src/main/res/layout/item_ignored_app.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:padding="12dp"
+    android:minHeight="56dp">
+
+    <ImageView
+        android:id="@+id/appIcon"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginEnd="12dp"
+        android:scaleType="fitCenter" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/appName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:maxLines="1"
+            android:ellipsize="end" />
+
+        <TextView
+            android:id="@+id/appPackage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="11sp"
+            android:textColor="#666666"
+            android:fontFamily="monospace"
+            android:maxLines="1"
+            android:ellipsize="end" />
+
+    </LinearLayout>
+
+    <CheckBox
+        android:id="@+id/appCheckBox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp" />
+
+</LinearLayout>


### PR DESCRIPTION
## Problem

StorageFixer applies `LEGACY_STORAGE: allow` and other AppOps globally to **every** non-system app. For modern messengers (Telegram, Nagram, WhatsApp, etc.) that use Android 13+ granular media permissions (`READ_MEDIA_IMAGES` / `READ_MEDIA_VIDEO` / `READ_MEDIA_AUDIO`), this completely breaks the in-app photo/video picker — the app loses access to MediaStore because `LEGACY_STORAGE` overrides the scoped media permission model.

Confirmed broken on Android 16 QPR2 (SDK 36) with `nu.gpu.nagram` and `org.telegram.messenger`.

## Solution

An **Ignored Apps** list. Any package added to it is fully skipped during all fix operations:

- `fixAll()` scan (boot + manual "Fix All")
- `PackageReceiver` auto-fix on app install/update
- `diagnosePackage()` — still runs diagnostics but skips the actual fix, logs a warning

Users open the new "Ignored Apps" screen, search for the app, check the box — done.

## Changes

| File | Description |
|---|---|
| `IgnoredAppsManager.java` | **new** — `SharedPreferences`-backed store for ignored package names |
| `IgnoredAppsActivity.java` | **new** — searchable list of installed apps with checkboxes (ignored sorted to top) |
| `activity_ignored_apps.xml` | **new** — layout (SearchView + ListView) |
| `item_ignored_app.xml` | **new** — list item (icon, app name, package name, checkbox) |
| `StorageFixer.java` | skip ignored in `fixAll()` loop; skip fix in `diagnosePackage()`; log count |
| `PackageReceiver.java` | early return for ignored packages |
| `MainActivity.java` | wire up "Ignored Apps" button |
| `activity_main.xml` | add outlined "Ignored Apps" button |
| `AndroidManifest.xml` | register `IgnoredAppsActivity` |
| `build.yml` | add `pull_request` trigger for CI |

## Testing

Tested on POCO F3, Android 16 QPR2 (BP4A.251205.006), KernelSU 3.1.0:

- PUBG Mobile — **not ignored** — StorageFixer applies fix, game works correctly
- Nagram (`nu.gpu.nagram`) — **added to ignore list** — photo picker works, MediaStore access intact
- Telegram — **added to ignore list** — in-app gallery works normally

No changes to existing fix logic for non-ignored apps.