### PR TITLE
register PackageReceiver within FixerService to try to solve app not receiving intents

### DIFF
--- a/app/src/main/java/com/omersusin/storagefixer/FixerService.java
+++ b/app/src/main/java/com/omersusin/storagefixer/FixerService.java
@@ -5,10 +5,12 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.ServiceInfo;
 import android.os.IBinder;
 
 import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -17,6 +19,7 @@ public class FixerService extends Service {
 
     private static final int NOTIF_ID = 1;
     private final AtomicBoolean running = new AtomicBoolean(false);
+    private PackageReceiver pkgReceiver;
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
@@ -33,12 +36,14 @@ public class FixerService extends Service {
                 if (!StorageFixer.isRootAvailable()) {
                     FixerLog.e("Root not available");
                     updateNotif("No root");
+                    shutdown();
                     return;
                 }
 
                 updateNotif("Waiting for storage...");
                 if (!StorageFixer.waitForFuse(60)) {
                     updateNotif("Storage timeout");
+                    shutdown();
                     return;
                 }
 
@@ -55,18 +60,50 @@ public class FixerService extends Service {
                 String msg = ok + "/" + results.size() + " fixed";
                 updateNotif(msg);
 
-                Thread.sleep(3000);
+                // Stay alive and watch for new installs/downloads
+                registerPackageReceiver();
+                updateNotif("Watching for installs (" + msg + ")");
 
             } catch (Exception e) {
                 FixerLog.e("Service error: " + e.getMessage());
-            } finally {
-                running.set(false);
-                stopForeground(STOP_FOREGROUND_REMOVE);
-                stopSelf();
+                shutdown();
             }
         }).start();
 
         return START_NOT_STICKY;
+    }
+
+    private void shutdown() {
+        running.set(false);
+        stopForeground(STOP_FOREGROUND_REMOVE);
+        stopSelf();
+    }
+
+    private void registerPackageReceiver() {
+        if (pkgReceiver != null) return;
+        pkgReceiver = new PackageReceiver();
+
+        IntentFilter pkg = new IntentFilter();
+        pkg.addAction(Intent.ACTION_PACKAGE_ADDED);
+        pkg.addAction(Intent.ACTION_PACKAGE_REPLACED);
+        pkg.addDataScheme("package");
+        ContextCompat.registerReceiver(this, pkgReceiver, pkg,
+                ContextCompat.RECEIVER_NOT_EXPORTED);
+
+        IntentFilter dl = new IntentFilter("android.intent.action.DOWNLOAD_COMPLETE");
+        ContextCompat.registerReceiver(this, pkgReceiver, dl,
+                ContextCompat.RECEIVER_NOT_EXPORTED);
+
+        FixerLog.i("Dynamic package receiver registered");
+    }
+
+    @Override
+    public void onDestroy() {
+        if (pkgReceiver != null) {
+            try { unregisterReceiver(pkgReceiver); } catch (Exception ignored) {}
+            pkgReceiver = null;
+        }
+        super.onDestroy();
     }
 
     private Notification buildNotif(String text) {


### PR DESCRIPTION
On my phone the service is not working because it is never receiving the broadcasted intents, probably because it is getting killed. With the registered PackageReceiver in the FixerService all intended broadcasts are received and the fixer does it's job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now continuously monitors for app installations and downloads in the background, with notification updates showing active monitoring status.

* **Improvements**
  * Enhanced service lifecycle management and receiver registration handling for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->